### PR TITLE
2.x

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+
+[*.js]
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 node_modules
 *.iml
+.nyc_output
+coverage
+*.lock

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,20 @@
+{
+  "boss": true,
+  "curly": false,
+  "devel": false,
+  "eqeqeq": true,
+  "eqnull": true,
+  "esversion": 6,
+  "expr": true,
+  "immed": true,
+  "mocha": true,
+  "noarg": true,
+  "node": true,
+  "node": true,
+  "onevar": true,
+  "quotmark": "single",
+  "smarttabs": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,19 @@
   "description": "Winston transport to stream logs to node-monitor-ui",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "jshint index.js test.js",
+    "test": "DEBUG=winston-node-monitor-ui mocha test.js",
+    "cover": "nyc --reporter=html --reporter=text  mocha test.js",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls"
+  },
+  "nyc": {
+    "all": true,
+    "include": [
+      "index.js"
+    ],
+    "exclude": [
+      "test.js"
+    ]
   },
   "repository": {
     "type": "git",
@@ -24,8 +36,19 @@
   },
   "homepage": "https://github.com/vigneshnrfs/winston-node-monitor-ui#readme",
   "dependencies": {
+    "chai": "^4.1.2",
+    "debug": "^3.1.0",
+    "jshint": "^2.9.5",
     "monotonic-timestamp": "0.0.9",
+    "nyc": "^11.7.3",
     "socket.io-client": "^1.4.8",
-    "winston": "^2.2.0"
+    "winston": "^2.4.2"
+  },
+  "devDependencies": {
+    "mocha": "^5.1.1",
+    "socket.io": "^2.1.0"
+  },
+  "peerDependencies": {
+    "winston": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "jshint": "^2.9.5",
     "monotonic-timestamp": "0.0.9",
     "nyc": "^11.7.3",
-    "socket.io-client": "^2.1.0",
-    "winston": "^2.4.2"
+    "socket.io-client": "^2.1.0"
   },
   "devDependencies": {
     "mocha": "^5.1.1",
-    "socket.io": "^2.1.0"
+    "socket.io": "^2.1.0",
+    "winston": "^2.4.2"
   },
   "peerDependencies": {
     "winston": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,19 +36,19 @@
   },
   "homepage": "https://github.com/vigneshnrfs/winston-node-monitor-ui#readme",
   "dependencies": {
-    "chai": "^4.1.2",
     "debug": "^3.1.0",
-    "jshint": "^2.9.5",
     "monotonic-timestamp": "0.0.9",
-    "nyc": "^11.7.3",
     "socket.io-client": "^2.1.0"
   },
   "devDependencies": {
+    "chai": "^4.1.2",
+    "jshint": "^2.9.5",
     "mocha": "^5.1.1",
+    "nyc": "^11.7.3",
     "socket.io": "^2.1.0",
-    "winston": "^2.4.2"
+    "winston": "^3.0.0-rc5"
   },
   "peerDependencies": {
-    "winston": "^2.0.0"
+    "winston": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "mocha": "^5.1.1",
     "nyc": "^11.7.3",
     "socket.io": "^2.1.0",
-    "winston": "^3.0.0-rc5"
+    "winston": "^2.4.2"
   },
   "peerDependencies": {
-    "winston": "^3.0.0"
+    "winston": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jshint": "^2.9.5",
     "monotonic-timestamp": "0.0.9",
     "nyc": "^11.7.3",
-    "socket.io-client": "^1.4.8",
+    "socket.io-client": "^2.1.0",
     "winston": "^2.4.2"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var winston = require('winston');
+var expect = require('chai').expect;
+require('./');
+
+describe('winston-node-monitor-ui', () => {
+  var logger;
+  var io;
+
+  before(() => {
+    logger = new winston.Logger();
+    io = require('socket.io')(3001);
+  });
+
+  after((done) => {
+    io.close(done);
+  });
+
+  it('NodeMonitorUI', (done) => {
+    const actual = [];
+    const expected = [
+      {
+        level: 'info',
+        meta: {
+          foo: 'quu'
+        },
+        msg: 'foo'
+      },
+      {
+        level: 'info',
+        meta: {
+          baz: 'qxx'
+        },
+        msg: 'bar'
+      }
+    ];
+
+    io.on('connection', (socket) => {
+      socket.on('logs', (log) => actual.push({level: log.level, meta: log.meta, msg: log.msg}));
+      socket.on('disconnect', () => {
+        expect(actual).to.deep.equal(expected);
+        done();
+      });
+    });
+
+    logger.add(winston.transports.NodeMonitorUI);
+
+    logger.info('foo', {foo: 'quu'});
+    logger.debug('skip');
+
+    setTimeout(() => {
+      logger.info('bar', {baz: 'qxx'});
+      logger.remove(logger.transports.NodeMonitorUI);
+    }, 500);
+  });
+});


### PR DESCRIPTION
Hi,

The following PR contains:
 - move winston to peer dependencies (it's the only breaking change of this PR but most users of have winston installed anyway)
 - fix an issue when first log not added to queue (state = NOT_INITIALIZED)
 - add editor config
 - add jshint
 - add tests
 - add coverage (you can integrate it with https://coveralls.io/ via travis, I can submit PR if needed)
 - add debug (DEBUG=winston-node-monitor-ui allow to see debug information)
 - bump deps (most important socket.io-client to fix https://nodesecurity.io/advisories/534)
 - lock peerDependencies to ^2.0.0 because (I'll pull 3.x version soon also)

Also, I'd recommend you to keep 2.x branch in the repo and release 2.0.0 version to keep support of winston 2.x and later switch main branch (master) to support winston 3.x only


